### PR TITLE
Clean up the Github action names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: 'Build Ghidra'
+    name: 'Build Ghidra - ${{ matrix.platform.os }} - ${{ matrix.ghidra.version }}'
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
The old names were auto-generated, use a more sensisble name.